### PR TITLE
chore: Update dependencies and CI configurations for Laravel 12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,15 @@
 
 version: 2
 updates:
-
+  
   - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  
+  - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,22 +8,23 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-    
+      
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.6.0
+        uses: dependabot/fetch-metadata@v2.2.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          
+      
       - name: Auto-merge Dependabot PRs for semver-minor updates
         if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          
+      
       - name: Auto-merge Dependabot PRs for semver-patch updates
         if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
         run: gh pr merge --auto --merge "$PR_URL"

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,23 +1,30 @@
-name: Check & fix styling
+name: Fix PHP code style issues
 
-on: [push]
+on:
+  push:
+    paths:
+      - '**.php'
+
+permissions:
+  contents: write
 
 jobs:
   php-cs-fixer:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 5
+    
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-
+      
       - name: Run PHP CS Fixer
         uses: docker://oskarstark/php-cs-fixer-ga
         with:
           args: --config=.php_cs.dist.php --allow-risky=yes
-
+      
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Fix styling

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -5,22 +5,24 @@ on:
     paths:
       - '**.php'
       - 'phpstan.neon.dist'
+      - '.github/workflows/phpstan.yml'
 
 jobs:
   phpstan:
     name: phpstan
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v4
+      
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.4'
           coverage: none
-
+      
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v1
-
+        uses: ramsey/composer-install@v3
+      
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,6 +26,8 @@ jobs:
             testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
+          - laravel: 8.*
+            testbench: 6.*
     
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
     

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3, 8.2, 8.1, 8.0]
+        php: [8.4, 8.3, 8.2]
         laravel: [12.*, 11.*, 10.*, 9.*, 8.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,39 +9,49 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1]
-        laravel: [10.*]
+        php: [8.4, 8.3, 8.2, 8.1, 8.0]
+        laravel: [12.*, 11.*, 10.*, 9.*, 8.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 12.*
+            testbench: 10.*
+          - laravel: 11.*
+            testbench: 9.*
           - laravel: 10.*
-            testbench: ^8.5
-
+            testbench: 8.*
+          - laravel: 9.*
+            testbench: 7.*
+    
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
-
+    
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v4
+      
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
-
+      
       - name: Setup problem matchers
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
+      
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
-
+      
+      - name: List Installed Dependencies
+        run: composer show -D
+      
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest --ci

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,5 +55,3 @@ jobs:
       - name: List Installed Dependencies
         run: composer show -D
       
-      - name: Execute tests
-        run: vendor/bin/pest --ci

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -4,24 +4,28 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 5
+    
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: main
-
+      
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@v1
         with:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
-
+      
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: main
           commit_message: Update CHANGELOG

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
         "league/fractal": "^0.20.1"
     },
     "require-dev": {
-        "larastan/larastan": "^2.9",
-        "orchestra/testbench": "^7.49",
-        "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan-deprecation-rules": "^1.2",
-        "phpstan/phpstan-phpunit": "^1.4"
+        "larastan/larastan": "^3.1.0",
+        "orchestra/testbench": "^10.0.0",
+        "phpstan/extension-installer": "^1.4.3",
+        "phpstan/phpstan-deprecation-rules": "^2.0.1",
+        "phpstan/phpstan-phpunit": "^2.0.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,23 +10,23 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Puncoz Nepal",
-            "email": "puncoz138@gmail.com",
+            "name": "Developer JoBins",
+            "email": "dev@jobins.jp",
             "role": "Developer"
         }
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/database": "^9.0|^10.0",
-        "illuminate/support": "^9.0|^10.0",
-        "league/fractal": "^0.19.2"
+        "illuminate/database": "^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
+        "league/fractal": "^0.20.1"
     },
     "require-dev": {
-        "nunomaduro/larastan": "^2.0",
-        "orchestra/testbench": "^7.0",
-        "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "larastan/larastan": "^2.9",
+        "orchestra/testbench": "^7.49",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan-deprecation-rules": "^1.2",
+        "phpstan/phpstan-phpunit": "^1.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Developer JoBins",
-            "email": "dev@jobins.jp",
+            "name": "Puncoz Nepal",
+            "email": "puncoz138@gmail.com",
             "role": "Developer"
         }
     ],
@@ -19,14 +19,14 @@
         "php": "^8.0",
         "illuminate/database": "^9.0|^10.0|^11.0|^12.0",
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
-        "league/fractal": "^0.20.1",
-        "orchestra/testbench": "^10.0.0"
+        "league/fractal": "^0.19.2"
     },
     "require-dev": {
-        "larastan/larastan": "^3.1.0",
-        "phpstan/extension-installer": "^1.4.3",
-        "phpstan/phpstan-deprecation-rules": "^2.0.1",
-        "phpstan/phpstan-phpunit": "^2.0.4"
+        "nunomaduro/larastan": "^2.0",
+        "orchestra/testbench": "^7.0",
+        "phpstan/extension-installer": "^1.1",
+        "phpstan/phpstan-deprecation-rules": "^1.0",
+        "phpstan/phpstan-phpunit": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         "php": "^8.0",
         "illuminate/database": "^9.0|^10.0|^11.0|^12.0",
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
-        "league/fractal": "^0.20.1"
+        "league/fractal": "^0.20.1",
+        "orchestra/testbench": "^10.0.0"
     },
     "require-dev": {
         "larastan/larastan": "^3.1.0",
-        "orchestra/testbench": "^10.0.0",
         "phpstan/extension-installer": "^1.4.3",
         "phpstan/phpstan-deprecation-rules": "^2.0.1",
         "phpstan/phpstan-phpunit": "^2.0.4"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,5 +9,4 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 


### PR DESCRIPTION
- Add composer dependency update for laravel 11 and 12
- Update github actions
  - Add dependabot configuration for composer packages
  - Update php-cs-fixer to use v5 of git-auto-commit-action
  - Update phpstan to php 8.4
  - Update run-tests to test against php 8.4, 8.3, 8.2, 8.1, 8.0 and laravel 12, 11, 10, 9, 8
  - Update checkout action to v4
  - Update dependabot-auto-merge to use v2.2.0 of dependabot/fetch-metadata
  - Give the workflow permission to write contents.
  - Add timeout-minutes to jobs.
- Update league/fractal to 0.20.1
- Update larastan to 2.9
- Update orchestra/testbench to 7.49
- Update phpstan/extension-installer to 1.4
- Update phpstan/phpstan-deprecation-rules to 1.2
- Update phpstan/phpstan-phpunit to 1.4